### PR TITLE
Fixes column names in logstash config

### DIFF
--- a/chapter-10/files/logstash_sensor_data_http.conf
+++ b/chapter-10/files/logstash_sensor_data_http.conf
@@ -19,15 +19,15 @@ filter {
   }
 
   mutate {
-    rename => {"[lookupResult][0][sensorType]" => "sensorType"}
+    rename => {"[lookupResult][0][sensortype]" => "sensorType"}
     rename => {"[lookupResult][0][customer]" => "customer"}
     rename => {"[lookupResult][0][department]" => "department"}
-    rename => {"[lookupResult][0][buildingName]" => "buildingName"}
+    rename => {"[lookupResult][0][buildingname]" => "buildingName"}
     rename => {"[lookupResult][0][room]" => "room"}
     rename => {"[lookupResult][0][floor]" => "floor"}
-    rename => {"[lookupResult][0][locationOnFloor]" => "locationOnFloor"}
+    rename => {"[lookupResult][0][locationonfloor]" => "locationOnFloor"}
     add_field => {
-      "location" => "%{[lookupResult][0][latitude]},%{[lookupResult][0][longitude]}"
+      "location" => "%{[lookupResult][0][latitude]},%{[lookupresult][0][longitude]}"
     }
     remove_field => ["lookupResult", "headers", "host"]
   }


### PR DESCRIPTION
The 'jdbc_streaming' plugin converts all column names to lowercase. This commit changes the column names in 'lookupResult' accordingly.